### PR TITLE
Redownload partial music files

### DIFF
--- a/netease/weapi.py
+++ b/netease/weapi.py
@@ -353,11 +353,11 @@ class Crawler(object):
             if valid_name != song_name:
                 click.echo('{} will be saved as: {}.mp3'.format(song_name, valid_name))
                 fpath = os.path.join(folder, valid_name + '.mp3')
-
-        if not os.path.exists(fpath):
+                
+        length = int(resp.headers.get('content-length'))
+        if not os.path.exists(fpath) or os.path.getsize(fpath) < length:
             resp = self.download_session.get(
                 song_url, timeout=self.timeout, stream=True)
-            length = int(resp.headers.get('content-length'))
             label = 'Downloading {} {}kb'.format(song_name, int(length/1024))
 
             with click.progressbar(length=length, label=label) as progressbar:


### PR DESCRIPTION
When interrupting a download process, only a part of the current file being downloading will be written to the disk. This results in a corrupted .mp3 file. Even redownloading won't fix the file content, since the file with that name already exists.

This change adds an additional check for the file size, to ensure the file to be redownloaded if it's not complete.