### PR TITLE
Allow customizing headers

### DIFF
--- a/netease/download.py
+++ b/netease/download.py
@@ -66,11 +66,12 @@ def login(method):
 class NetEase(object):
     """Provide download operation."""
 
-    def __init__(self, timeout, proxy, folder, quiet, lyric, again):
-        self.crawler = Crawler(timeout, proxy)
+    def __init__(self, timeout, proxy, folder, headers, quiet, lyric, again):
+        self.crawler = Crawler(timeout, proxy, headers)
         self.folder = '.' if folder is None else folder
         self.quiet = quiet
         self.lyric = lyric
+        self.headers = headers
         try:
             if again:
                 self.crawler.login()

--- a/netease/start.py
+++ b/netease/start.py
@@ -34,13 +34,15 @@ signal.signal(signal.SIGINT, signal_handler)
 @click.option('-p', '--proxy', help='Use the specified HTTP/HTTPS/SOCKS proxy.')
 @click.option('-o', '--output', type=click.Path(exists=True),
               help='Specify the storage path.')
+@click.option('-h', '--header', multiple=True, help='Extra header(s) for HTTP requests.')
 @click.option('-q', '--quiet', is_flag=True, help='Automatically select the best one.')
 @click.option('-l', '--lyric', is_flag=True, help='Download lyric.')
 @click.option('-a', '--again', is_flag=True, help='Login Again.')
 @click.pass_context
-def cli(ctx, timeout, proxy, output, quiet, lyric, again):
+def cli(ctx, timeout, proxy, output, headers, quiet, lyric, again):
     """A command tool to download NetEase-Music's songs."""
-    ctx.obj = NetEase(timeout, proxy, output, quiet, lyric, again)
+    headers = dict(map(lambda h: re.split(':\s?', h), headers))
+    ctx.obj = NetEase(timeout, proxy, output, headers, quiet, lyric, again)
 
 
 @cli.command()

--- a/netease/weapi.py
+++ b/netease/weapi.py
@@ -55,13 +55,14 @@ def exception_handle(method):
 class Crawler(object):
     """NetEase Music API."""
 
-    def __init__(self, timeout=60, proxy=None):
+    def __init__(self, timeout=60, proxy=None, headers={}):
         self.session = requests.Session()
         self.session.headers.update(headers)
         self.session.cookies = cookielib.LWPCookieJar(cookie_path)
         self.download_session = requests.Session()
         self.timeout = timeout
         self.proxies = {'http': proxy, 'https': proxy}
+        self.headers = headers
 
         self.display = Display()
 
@@ -74,7 +75,8 @@ class Crawler(object):
         """
 
         resp = self.session.get(url, timeout=self.timeout,
-                                proxies=self.proxies)
+                                proxies=self.proxies,
+                                headers=self.headers)
         result = resp.json()
         if result['code'] != 200:
             LOG.error('Return %s when try to get %s', result, url)
@@ -91,7 +93,8 @@ class Crawler(object):
 
         data = encrypted_request(params)
         resp = self.session.post(url, data=data, timeout=self.timeout,
-                                 proxies=self.proxies)
+                                 proxies=self.proxies,
+                                 headers=self.headers)
         result = resp.json()
         if result['code'] != 200:
             LOG.error('Return %s when try to post %s => %s',


### PR DESCRIPTION
In fact, to circumvent NetEase's country restriction, there's a much easier way that doesn't require a proxy. By setting the HTTP header 'X-Real-IP' to an IP address in China, you may easily cheat NetEase's servers into treating this request as from China, allowing you to download, search, etc without any location restriction.

This PR added the functionality to specify any customized headers for HTTP requests. This allows users to take advantage of the trick said above.
